### PR TITLE
Two fixes

### DIFF
--- a/delphin/mrs/dmrx.py
+++ b/delphin/mrs/dmrx.py
@@ -35,7 +35,7 @@ def load(fh, single=False):
 def loads(s, single=False):
     corpus = etree.fromstring(s)
     if single:
-        ds = decode_dmrs(next(corpus))
+        ds = decode_dmrs(next(iter(corpus)))
     else:
         ds = (decode_dmrs(dmrs_elem) for dmrs_elem in corpus)
     return ds

--- a/delphin/mrs/xmrs.py
+++ b/delphin/mrs/xmrs.py
@@ -704,7 +704,7 @@ def Dmrs(nodes=None, links=None,
 def _make_labels(nodes, links, vgen):
     labels = {}
     labels[LTOP_NODEID] = vgen.new(HANDLESORT)[0]  # reserve h0 for ltop
-    for l in links:
+    for l in sorted(links, key=lambda l: min(l.start, l.end)):
         if l.post == EQ_POST:
             lbl = (labels.get(l.start) or
                    labels.get(l.end) or


### PR DESCRIPTION
- The change in dmrx.py:38 makes the function Python3-compatible, but should not hurt Python2-compatibility (for all I know).
- The change in xmrs.py:707 fixes a bug I encountered for cases when the "natural" ordering of the links is unfavourable. This was the case for me in the following setting, where the EQ links were the following: 10004 --> 10005, 10006 --> 10007, 10007 --> 10005. Although all nodes should get the same label, the ordering caused 10004 to get a different label from the rest (10005 got re-set because of the last link).