### PR TITLE
Fix for ACE generation errors.

### DIFF
--- a/delphin/interfaces/ace.py
+++ b/delphin/interfaces/ace.py
@@ -120,7 +120,7 @@ class AceGenerator(AceProcess):
             line = stdout.readline().rstrip()
         # sometimes error messages aren't prefixed with ERROR
         if line.endswith('[0 results]') and len(results) > 0:
-            response['ERRORS'] = '\n'.join(results)
+            response['ERRORS'] = '\n'.join(d['SENT'] for d in results)
             results = []
         response['RESULTS'] = results
         return response


### PR DESCRIPTION
List of dictionaries can't be joined, instead first extract the corresponding string argument.