### PR TITLE
More LaTeX fixes: better baseline for DMRS, show CARGs

### DIFF
--- a/delphin/extra/latex.py
+++ b/delphin/extra/latex.py
@@ -61,10 +61,11 @@ def dmrs_tikz_dependency(xs):
     slots = defaultdict(set)  # from/(+-)to; + for above, - for below
     lines = """\\documentclass{standalone}
 \\usepackage{tikz-dependency}
+\\usepackage{relsize}
 %%%
 %%% style for dmrs graph
 %%%
-\\depstyle{dmrs}{label style={above, scale=.8, opacity=0, text opacity=1},
+\\depstyle{dmrs}{label style={above, scale=.9, opacity=0, text opacity=1},
   edge unit distance=1.5ex}
 %%% set text opacity=0 to hide text, opacity = 0 to hide box
 \\depstyle{root}{edge unit distance=3ex, label style={opacity=1}}
@@ -74,6 +75,8 @@ def dmrs_tikz_dependency(xs):
 \\depstyle{icons}{edge below, dashed}
 \\providecommand{\\spred}{} %% may be defined in mrs.sty
 \\renewcommand{\\spred}[1]{\\mbox{\\textsf{#1}}}
+\\providecommand{\\srl}{} %% may be defined in mrs.sty
+\\renewcommand{\\srl}[1]{\\mbox{\\textsf{\\smaller #1}}}
 %%%
 \\begin{document}""".split("\n")
     
@@ -98,7 +101,7 @@ def dmrs_tikz_dependency(xs):
                 lines.append(
                     '  \\deproot[root]{{{}}}{{{}}}'.format(
                         nodeidx[link.end],
-                        'TOP'  # _latex_escape('/' + link.post)
+                        '\\srl{TOP}'  # _latex_escape('/' + link.post)
                     )
                 )
             else:
@@ -106,7 +109,7 @@ def dmrs_tikz_dependency(xs):
                 # if slot in slots[link.start]:
                 #     opts.append('edge unit distance=4ex')
                 # slots[link.start].add(slot)
-                lines.append('  \\depedge[{}]{{{}}}{{{}}}{{{}}}'.format(
+                lines.append('  \\depedge[{}]{{{}}}{{{}}}{{\\srl{{{}}}}}'.format(
                     label_edge(link),
                     nodeidx[link.start],
                     nodeidx[link.end],

--- a/delphin/extra/latex.py
+++ b/delphin/extra/latex.py
@@ -65,8 +65,9 @@ def dmrs_tikz_dependency(xs):
 %%%
 %%% style for dmrs graph
 %%%
-\\depstyle{dmrs}{label style={above, scale=.9, opacity=0, text opacity=1},
-  edge unit distance=1.5ex}
+\\depstyle{dmrs}{edge unit distance=1.5ex, 
+  label style={above, scale=.9, opacity=0, text opacity=1},
+  baseline={([yshift=-0.7\\baselineskip]current bounding box.north)}}
 %%% set text opacity=0 to hide text, opacity = 0 to hide box
 \\depstyle{root}{edge unit distance=3ex, label style={opacity=1}}
 \\depstyle{arg}{edge above}

--- a/delphin/extra/latex.py
+++ b/delphin/extra/latex.py
@@ -58,10 +58,11 @@ def dmrs_tikz_dependency(xs):
     if isinstance(xs, Xmrs):
         xs = [xs]
 
-    slots = defaultdict(set)  # from/(+-)to; + for above, - for below
     lines = """\\documentclass{standalone}
+
 \\usepackage{tikz-dependency}
 \\usepackage{relsize}
+
 %%%
 %%% style for dmrs graph
 %%%
@@ -74,26 +75,26 @@ def dmrs_tikz_dependency(xs):
 \\depstyle{rstr}{edge below, dotted, label style={text opacity=1}}
 \\depstyle{eq}{edge below, label style={text opacity=1}}
 \\depstyle{icons}{edge below, dashed}
-\\providecommand{\\spred}{} %% may be defined in mrs.sty
+
+%%% styles for predicates and roles (from mrs.sty)
+\\providecommand{\\spred}{} 
 \\renewcommand{\\spred}[1]{\\mbox{\\textsf{#1}}}
-\\providecommand{\\srl}{} %% may be defined in mrs.sty
+\\providecommand{\\srl}{} 
 \\renewcommand{\\srl}[1]{\\mbox{\\textsf{\\smaller #1}}}
 %%%
+
 \\begin{document}""".split("\n")
     
     for x in xs:
         lines.append("\\begin{dependency}[dmrs]")
         ns = nodes(x)
-        ls = links(x)
         ### predicates
         lines.append("  \\begin{deptext}[column sep=10pt]")
         for i, n in enumerate(ns):
-            if i < len(ns) -1:
-                sep = "\\&"
-            else:
-                sep = "\\\\"
-            lines.append("    \\spred{{{}}} {}     % node {}".format(_latex_escape(n.pred.short_form()),
-                                                                  sep, i+1))
+            sep = "\\&"  if  (i < len(ns) - 1) else  "\\\\"
+            lines.append("    \\spred{{{}}} {}     % node {}".format(
+                _latex_escape(n.pred.short_form()), sep, i+1))
+
         lines.append("  \\end{deptext}")
         nodeidx = {n.nodeid: i+1 for i, n in enumerate(ns)}
         ### links
@@ -106,10 +107,6 @@ def dmrs_tikz_dependency(xs):
                     )
                 )
             else:
-                # slot = link.end * -1 if side.endswith('below') else link.end
-                # if slot in slots[link.start]:
-                #     opts.append('edge unit distance=4ex')
-                # slots[link.start].add(slot)
                 lines.append('  \\depedge[{}]{{{}}}{{{}}}{{\\srl{{{}}}}}'.format(
                     label_edge(link),
                     nodeidx[link.start],
@@ -117,7 +114,7 @@ def dmrs_tikz_dependency(xs):
                     _latex_escape(link_label(link))
                 ))
         ### placeholder for icons
-        lines.append('%  \\depedge[icons]{f}{t}{focus}')
+        lines.append('%  \\depedge[icons]{f}{t}{FOCUS}')
         lines.append('\\end{dependency}\n')
     lines.append('\\end{document}')
     return '\n'.join(lines)

--- a/delphin/extra/latex.py
+++ b/delphin/extra/latex.py
@@ -75,6 +75,8 @@ def dmrs_tikz_dependency(xs):
 \\depstyle{rstr}{edge below, dotted, label style={text opacity=1}}
 \\depstyle{eq}{edge below, label style={text opacity=1}}
 \\depstyle{icons}{edge below, dashed}
+\\providecommand{\\named}{}  
+\\renewcommand{\\named}{named}
 
 %%% styles for predicates and roles (from mrs.sty)
 \\providecommand{\\spred}{} 
@@ -85,16 +87,21 @@ def dmrs_tikz_dependency(xs):
 
 \\begin{document}""".split("\n")
     
-    for x in xs:
+    for ix, x in enumerate(xs):
+        lines.append("%%%\n%%% {}\n%%%".format(ix+1)) 
         lines.append("\\begin{dependency}[dmrs]")
         ns = nodes(x)
         ### predicates
         lines.append("  \\begin{deptext}[column sep=10pt]")
         for i, n in enumerate(ns):
             sep = "\\&"  if  (i < len(ns) - 1) else  "\\\\"
+            pred = _latex_escape(n.pred.short_form())
+            pred = "\\named{}" if pred == 'named' else pred
+            if n.carg is not None:
+                print(n.carg.strip('"'))
+                pred += "\\smaller ({})".format(n.carg.strip('"'))
             lines.append("    \\spred{{{}}} {}     % node {}".format(
-                _latex_escape(n.pred.short_form()), sep, i+1))
-
+                pred, sep, i+1))
         lines.append("  \\end{deptext}")
         nodeidx = {n.nodeid: i+1 for i, n in enumerate(ns)}
         ### links


### PR DESCRIPTION
I cleaned things up a bit, deleted some old stuff, made roles format in the same way as mrs.sty added CARGs and set the baseline for DMRS so that it looks good when you use it in an example.