### PR TITLE
Non-ascii XML output now allowed in Python2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * The following dump methods now allow either a file or filename as their arguments like
   `delphin.mrs.penman.dump()`: `delphin.mrs.eds.dump()`, `delphin.mrs.simplemrs.dump()`, `delphin.mrs.simpledmrs.dump()`, `delphin.mrs.mrx.dump()`, `delphin.mrs.dmrx.dump()`,
   `delphin.mrs.prolog.dump()` (#152)
+* Non-ascii XML output is now able to be processed in Python2 (#106)
 
 
 ### Deprecated

--- a/delphin/mrs/util.py
+++ b/delphin/mrs/util.py
@@ -90,7 +90,25 @@ try:
     etree_tostring = etree.tostring
 except LookupError:
     def etree_tostring(elem, encoding='unicode', **kwargs):
+        _etree_str_to_unicode(elem)
         if encoding == 'unicode':
             return etree.tostring(elem, encoding='utf-8', **kwargs).decode('utf-8')
         else:
             return etree.tostring(elem, encoding=encoding, **kwargs)
+
+def _etree_str_to_unicode(e, encoding='utf-8'):
+    if isinstance(e.tag, str):
+        e.tag = unicode(e.tag, encoding)
+    if isinstance(e.text, str):
+        e.text = unicode(e.text, encoding)
+    if isinstance(e.tail, str):
+        e.tail = unicode(e.tail, encoding)
+    for attr, val in list(e.attrib.items()):
+        del e.attrib[attr]
+        if isinstance(attr, str):
+            attr = unicode(attr, encoding)
+        if isinstance(val, str):
+            val = unicode(val, encoding)
+        e.attrib[attr] = val
+    for child in e:
+        _etree_str_to_unicode(child, encoding)

--- a/tests/mrs_util_test.py
+++ b/tests/mrs_util_test.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+from delphin.mrs.util import etree_tostring
+
+def test_etree_tostring():
+    import xml.etree.ElementTree as etree
+    e = etree.Element('a')
+    e.text = 'a'
+    assert etree_tostring(e, encoding='unicode') == u'<a>a</a>'
+    e.text = u'あ'
+    assert etree_tostring(e, encoding='unicode') == u'<a>あ</a>'
+    e.text = 'あ'
+    assert etree_tostring(e, encoding='unicode') == u'<a>あ</a>'
+    b = etree.SubElement(e, 'b')
+    b.text = 'あ'
+    assert etree_tostring(e, encoding='unicode') == u'<a>あ<b>あ</b></a>'


### PR DESCRIPTION
Fixes #106