### PR TITLE
Fix #360: remove implicit optional types

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,4 +37,4 @@ jobs:
         pytest .
     - name: Type-check with mypy
       run: |
-        mypy delphin --namespace-packages --explicit-package-bases --ignore-missing-imports --implicit-optional
+        mypy delphin --namespace-packages --explicit-package-bases --ignore-missing-imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `delphin.tdl.ConsList.values()` and `delphin.tdl.DiffList.values()`
   now treat explicit sublists as regular items instead of descending
   into their structures ([#357])
+* Implicit optional types are made explicit ([#360])
 
 
 ## [v1.7.0]
@@ -1566,3 +1567,4 @@ information about changes, except for
 [#344]: https://github.com/delph-in/pydelphin/issues/344
 [#352]: https://github.com/delph-in/pydelphin/issues/352
 [#357]: https://github.com/delph-in/pydelphin/issues/357
+[#360]: https://github.com/delph-in/pydelphin/issues/360

--- a/delphin/ace.py
+++ b/delphin/ace.py
@@ -4,7 +4,8 @@ An interface for the ACE processor.
 """
 
 from typing import (
-    Any, Iterator, Iterable, Mapping, Dict, List, Tuple, Pattern, IO)
+    Any, Iterator, Iterable, Mapping, Dict, List, Tuple, Pattern, IO, Optional
+)
 import logging
 import os
 from pathlib import Path
@@ -77,12 +78,12 @@ class ACEProcess(interface.Processor):
 
     def __init__(self,
                  grm: util.PathLike,
-                 cmdargs: List[str] = None,
-                 executable: util.PathLike = None,
-                 env: Mapping[str, str] = None,
+                 cmdargs: Optional[List[str]] = None,
+                 executable: Optional[util.PathLike] = None,
+                 env: Optional[Mapping[str, str]] = None,
                  tsdbinfo: bool = True,
                  full_forest: bool = False,
-                 stderr: IO[Any] = None):
+                 stderr: Optional[IO[Any]] = None):
         self.grm = str(Path(grm).expanduser())
 
         self.cmdargs = cmdargs or []
@@ -149,7 +150,10 @@ class ACEProcess(interface.Processor):
         self.close()
         return False  # don't try to handle any exceptions
 
-    def _result_lines(self, termini: List[Pattern[str]] = None) -> List[str]:
+    def _result_lines(
+        self,
+        termini: Optional[List[Pattern[str]]] = None
+    ) -> List[str]:
         poll = self._p.poll
         assert self._p.stdout is not None, 'cannot receive output from ACE'
         next_line = self._p.stdout.readline
@@ -270,7 +274,8 @@ class ACEProcess(interface.Processor):
 
     def process_item(self,
                      datum: str,
-                     keys: Dict[str, Any] = None) -> interface.Response:
+                     keys: Optional[Dict[str, Any]] = None
+                     ) -> interface.Response:
         """
         Send *datum* to ACE and return the response with context.
 
@@ -348,10 +353,10 @@ class ACETransferer(ACEProcess):
 
     def __init__(self,
                  grm: util.PathLike,
-                 cmdargs: List[str] = None,
-                 executable: util.PathLike = None,
-                 env: Mapping[str, str] = None,
-                 stderr: IO[Any] = None):
+                 cmdargs: Optional[List[str]] = None,
+                 executable: Optional[util.PathLike] = None,
+                 env: Optional[Mapping[str, str]] = None,
+                 stderr: Optional[IO[Any]] = None):
         super().__init__(grm, cmdargs=cmdargs, executable=executable, env=env,
                          tsdbinfo=False, full_forest=False, stderr=stderr)
 
@@ -378,11 +383,11 @@ class ACEGenerator(ACEProcess):
 
     def __init__(self,
                  grm: util.PathLike,
-                 cmdargs: List[str] = None,
-                 executable: util.PathLike = None,
-                 env: Mapping[str, str] = None,
+                 cmdargs: Optional[List[str]] = None,
+                 executable: Optional[util.PathLike] = None,
+                 env: Optional[Mapping[str, str]] = None,
                  tsdbinfo: bool = True,
-                 stderr: IO[Any] = None):
+                 stderr: Optional[IO[Any]] = None):
         super().__init__(grm, cmdargs=cmdargs, executable=executable, env=env,
                          tsdbinfo=tsdbinfo, full_forest=False, stderr=stderr)
 
@@ -422,10 +427,10 @@ class ACEGenerator(ACEProcess):
 
 def compile(cfg_path: util.PathLike,
             out_path: util.PathLike,
-            executable: util.PathLike = None,
-            env: Mapping[str, str] = None,
-            stdout: IO[Any] = None,
-            stderr: IO[Any] = None) -> None:
+            executable: Optional[util.PathLike] = None,
+            env: Optional[Mapping[str, str]] = None,
+            stdout: Optional[IO[Any]] = None,
+            stderr: Optional[IO[Any]] = None) -> None:
     """
     Use ACE to compile a grammar.
 

--- a/delphin/commands.py
+++ b/delphin/commands.py
@@ -3,7 +3,7 @@
 PyDelphin API counterparts to the ``delphin`` commands.
 """
 
-from typing import Union, Iterator, IO, Dict, Any
+from typing import Union, Iterator, IO, Dict, Any, Optional
 import sys
 from pathlib import Path
 import tempfile
@@ -41,10 +41,10 @@ def convert(path: Union[util.PathLike, IO[str]],
             properties: bool = True,
             lnk: bool = True,
             color: bool = False,
-            indent: int = None,
+            indent: Optional[int] = None,
             show_status: bool = False,
             predicate_modifiers: bool = False,
-            semi: Union[SemI, util.PathLike] = None) -> str:
+            semi: Optional[Union[SemI, util.PathLike]] = None) -> str:
     """
     Convert between various DELPH-IN Semantics representations.
 

--- a/delphin/derivation.py
+++ b/delphin/derivation.py
@@ -217,7 +217,7 @@ class UDFNode(_UDFNodeBase,
                 score: Optional[float] = None,
                 start: Optional[int] = None,
                 end: Optional[int] = None,
-                daughters: Optional[Sequence[_UDFNodeBase]] = None,
+                daughters: Optional[SequenceType[_UDFNodeBase]] = None,
                 head: Optional[bool] = None,
                 type: Optional[str] = None,
                 parent: Optional['UDFNode'] = None):

--- a/delphin/derivation.py
+++ b/delphin/derivation.py
@@ -149,7 +149,7 @@ class UDFTerminal(_UDFNodeBase, namedtuple('UDFTerminal', 'form tokens')):
 
     def __new__(cls,
                 form: str,
-                tokens: Optional[Sequence[UDFToken]] = None,
+                tokens: Optional[SequenceType[UDFToken]] = None,
                 parent=None):
         if tokens is None:
             tokens = []

--- a/delphin/derivation.py
+++ b/delphin/derivation.py
@@ -2,6 +2,15 @@
 Classes and functions related to derivation trees.
 """
 
+from typing import (
+    Optional,
+    Union,
+    List,
+    Dict,
+    Any,
+    Iterable,
+    Sequence as SequenceType,
+)
 import re
 from collections import namedtuple
 from collections.abc import Sequence
@@ -29,58 +38,32 @@ _all_fields = (
 )
 
 
-def from_string(s):
-    """
-    Instantiate a Derivation from a UDF or UDX string representation.
-
-    The UDF/UDX representations are as output by a processor like the
-    `LKB <https://github.com/delph-in/docs/wiki/LkbTop>`_ or
-    `ACE <http://sweaglesw.org/linguistics/ace/>`_, or from the
-    :meth:`UDFNode.to_udf` or :meth:`UDFNode.to_udx` methods.
-
-    Args:
-        s (str): UDF or UDX serialization
-    """
-    udfnode = _from_string(s)
-    return Derivation(*udfnode, head=udfnode._head, type=udfnode.type)
-
-
-def from_dict(d):
-    """
-    Instantiate a Derivation from a dictionary representation.
-
-    The dictionary representation may come from the HTTP interface
-    (see the `ErgApi <https://github.com/delph-in/docs/wiki/ErgApi>`_
-    wiki) or from the :meth:`UDFNode.to_dict` method. Note that in the
-    former case, the JSON response should have already been decoded
-    into a Python dictionary.
-
-    Args:
-        d (dict): dictionary representation of a derivation
-    """
-    return Derivation(*_from_dict(d))
-
-
 class _UDFNodeBase:
     """
     Base class for :class:`UDFNode` and :class:`UDFTerminal`.
     """
+    _parent: Optional['_UDFNodeBase']
+
     def __str__(self):
         return self.to_udf(indent=None)
 
     # cannot rely on default __ne__ while namedtuple is a shared base class
-    def __ne__(self, other):
+    def __ne__(self, other: Any):
         if not isinstance(other, _UDFNodeBase):
             return NotImplemented
         return not (self == other)
 
     @property
-    def parent(self):
+    def parent(self) -> Optional['_UDFNodeBase']:
         return self._parent
+
+    def is_root(self):
+        """Return True if the node is a root node."""
+        raise NotImplementedError()
 
     # serialization
 
-    def to_udf(self, indent=1):
+    def to_udf(self, indent: int = 1) -> str:
         """
         Encode the node and its descendants in the UDF format.
 
@@ -91,7 +74,7 @@ class _UDFNodeBase:
         """
         return _to_udf(self, indent, 1)
 
-    def to_udx(self, indent=1):
+    def to_udx(self, indent: int = 1) -> str:
         """
         Encode the node and its descendants in the UDF export format.
 
@@ -102,12 +85,16 @@ class _UDFNodeBase:
         """
         return _to_udf(self, indent, 1, udx=True)
 
-    def to_dict(self, fields=_all_fields, labels=None):
+    def to_dict(
+        self,
+        fields: Iterable[str] = _all_fields,
+        labels: Optional[SequenceType] = None
+    ) -> Dict[str, Any]:
         """
         Encode the node as a dictionary suitable for JSON serialization.
 
         Args:
-            fields: if given, this is a whitelist of fields to include
+            fields: if given, this is an allowlist of fields to include
                 on nodes (`daughters` and `form` are always shown)
             labels: optional label annotations to embed in the
                 derivation dict; the value is a list of lists matching
@@ -128,13 +115,11 @@ class UDFToken(namedtuple('UDFToken', 'id tfs')):
     multi-word entities (e.g. "ad hoc") will have more than one.
 
     Args:
-        id (int): token identifier
-        tfs (str): the feature structure for the token
+        id: token identifier
+        tfs: the feature structure for the token
     """
-    def __new__(cls, id, tfs):
-        if id is not None:
-            id = int(id)
-        return super(UDFToken, cls).__new__(cls, id, tfs)
+    def __new__(cls, id: Union[int, str], tfs: str):
+        return super(UDFToken, cls).__new__(cls, int(id), tfs)
 
     def __repr__(self):
         return f'<UDFToken object ({self.id} {self.tfs!r}) at {id(self)}>'
@@ -162,7 +147,10 @@ class UDFTerminal(_UDFNodeBase, namedtuple('UDFTerminal', 'form tokens')):
         parent (UDFNode, optional): parent node in derivation
     """
 
-    def __new__(cls, form, tokens=None, parent=None):
+    def __new__(cls,
+                form: str,
+                tokens: Optional[Sequence[UDFToken]] = None,
+                parent=None):
         if tokens is None:
             tokens = []
         t = super(UDFTerminal, cls).__new__(cls, form, tokens)
@@ -209,23 +197,30 @@ class UDFNode(_UDFNodeBase,
     daughters are terminal nodes.
 
     Args:
-        id (int): unique node identifier
-        entity (str): grammar entity represented by the node
-        score (float, optional): probability or weight of the node
-        start (int, optional): start position of tokens encompassed by
-            the node
-        end (int, optional): end position of tokens encompassed by the
-            node
-        daughters (list, optional): iterable of daughter nodes
-        head (bool, optional): `True` if the node is a syntactic head
-            node
-        type (str, optional): grammar type name
-        parent (UDFNode, optional): parent node in derivation
+        id: unique node identifier
+        entity: grammar entity represented by the node
+        score: probability or weight of the node
+        start: start position of tokens encompassed by the node
+        end: end position of tokens encompassed by the node
+        daughters: iterable of daughter nodes
+        head: `True` if the node is a syntactic head node
+        type: grammar type name
+        parent: parent node in derivation
     """
 
-    def __new__(cls, id, entity,
-                score=None, start=None, end=None, daughters=None,
-                head=None, type=None, parent=None):
+    _head: Optional[bool]
+    type: Optional[str]
+
+    def __new__(cls,
+                id: Optional[int],
+                entity: str,
+                score: Optional[float] = None,
+                start: Optional[int] = None,
+                end: Optional[int] = None,
+                daughters: Optional[Sequence[_UDFNodeBase]] = None,
+                head: Optional[bool] = None,
+                type: Optional[str] = None,
+                parent: Optional['UDFNode'] = None):
         # numeric fields can be underspecified as -1 if not a root
         if id is not None:
             id = int(id)
@@ -379,6 +374,38 @@ class Derivation(UDFNode):
                 )
 
 
+def from_string(s: str) -> Derivation:
+    """
+    Instantiate a Derivation from a UDF or UDX string representation.
+
+    The UDF/UDX representations are as output by a processor like the
+    `LKB <https://github.com/delph-in/docs/wiki/LkbTop>`_ or
+    `ACE <http://sweaglesw.org/linguistics/ace/>`_, or from the
+    :meth:`UDFNode.to_udf` or :meth:`UDFNode.to_udx` methods.
+
+    Args:
+        s (str): UDF or UDX serialization
+    """
+    udfnode = _from_string(s)
+    return Derivation(*udfnode, head=udfnode._head, type=udfnode.type)
+
+
+def from_dict(d: Dict[str, Any]) -> Derivation:
+    """
+    Instantiate a Derivation from a dictionary representation.
+
+    The dictionary representation may come from the HTTP interface
+    (see the `ErgApi <https://github.com/delph-in/docs/wiki/ErgApi>`_
+    wiki) or from the :meth:`UDFNode.to_dict` method. Note that in the
+    former case, the JSON response should have already been decoded
+    into a Python dictionary.
+
+    Args:
+        d (dict): dictionary representation of a derivation
+    """
+    return Derivation(*_from_dict(d))
+
+
 ###############################################################################
 # Deserialization
 
@@ -408,13 +435,13 @@ _udf_re = re.compile(
 )
 
 
-def _from_string(s):
+def _from_string(s) -> UDFNode:
     if not (s.startswith('(') and s.endswith(')')):
         raise DerivationSyntaxError(
             'missing opening or closing parentheses', text=s)
     s_ = s[1:]  # get rid of initial open-parenthesis
-    stack = []
-    deriv = None
+    stack: List[UDFNode] = []
+    deriv: Optional[UDFNode] = None
     matches = _udf_re.finditer(s_)
     for match in matches:
         if match.group('done'):
@@ -429,7 +456,7 @@ def _from_string(s):
             # ignore LKB-style start/end data if it exists on gd
             term = UDFTerminal(
                 _unquote(gd['form']),
-                tokens=_udf_tokens(gd.get('tokens')),
+                tokens=_udf_tokens(gd.get('tokens', '')),
                 parent=stack[-1] if stack else None
             )
             stack[-1].daughters.append(term)
@@ -442,9 +469,13 @@ def _from_string(s):
                 head = True
             if type == '':
                 type = None
-            udf = UDFNode(gd['id'], entity, gd['score'],
-                          gd['start'], gd['end'],
-                          head=head, type=type,
+            udf = UDFNode(int(gd['id']),
+                          entity,
+                          score=float(gd['score']) if gd['score'] else None,
+                          start=int(gd['start']) if gd['start'] else None,
+                          end=int(gd['end']) if gd['end'] else None,
+                          head=head,
+                          type=type,
                           parent=stack[-1] if stack else None)
             stack.append(udf)
         elif match.group('root'):
@@ -458,14 +489,14 @@ def _from_string(s):
     return deriv
 
 
-def _unquote(s):
+def _unquote(s: str) -> str:
     if s is not None:
         return re.sub(r'^"(.*)"$', r'\1', s)
     return None
 
 
-def _udf_tokens(tokenstring):
-    tokens = []
+def _udf_tokens(tokenstring: str) -> List[UDFToken]:
+    tokens: List[UDFToken] = []
     if tokenstring:
         toks = re.findall(
             r'\s*({id})\s+({tfs})'
@@ -477,7 +508,7 @@ def _udf_tokens(tokenstring):
     return tokens
 
 
-def _from_dict(d, parent=None):
+def _from_dict(d: Dict[str, Any], parent: Optional[UDFNode] = None) -> UDFNode:
     if 'daughters' in d:
         n = UDFNode(
             d.get('id'),
@@ -513,6 +544,8 @@ def _from_dict(d, parent=None):
             )
         )
         return n
+    else:
+        raise ValueError(f"invalid UDF node: {d}")
 
 
 ###############################################################################

--- a/delphin/dmrs/_dmrs.py
+++ b/delphin/dmrs/_dmrs.py
@@ -1,5 +1,5 @@
 
-from typing import Iterable
+from typing import Iterable, Optional
 
 from delphin import variable
 from delphin.lnk import Lnk
@@ -55,10 +55,10 @@ class Node(Predication):
     def __init__(self,
                  id: int,
                  predicate: str,
-                 type: str = None,
-                 properties: dict = None,
-                 carg: str = None,
-                 lnk: Lnk = None,
+                 type: Optional[str] = None,
+                 properties: Optional[dict] = None,
+                 carg: Optional[str] = None,
+                 lnk: Optional[Lnk] = None,
                  surface=None,
                  base=None):
         id = int(id)
@@ -173,11 +173,11 @@ class DMRS(scope.ScopingSemanticStructure):
     __slots__ = ('links')
 
     def __init__(self,
-                 top: int = None,
-                 index: int = None,
-                 nodes: Iterable[Node] = None,
-                 links: Iterable[Link] = None,
-                 lnk: Lnk = None,
+                 top: Optional[int] = None,
+                 index: Optional[int] = None,
+                 nodes: Optional[Iterable[Node]] = None,
+                 links: Optional[Iterable[Link]] = None,
+                 lnk: Optional[Lnk] = None,
                  surface=None,
                  identifier=None):
 

--- a/delphin/dmrs/_operations.py
+++ b/delphin/dmrs/_operations.py
@@ -3,7 +3,7 @@
 Operations on DMRS structures
 """
 
-from typing import Optional, Dict, List, Callable
+from typing import Optional, Dict, List, Callable, cast
 import warnings
 
 from delphin import variable
@@ -17,7 +17,7 @@ _IdMap = Dict[str, int]
 
 
 def from_mrs(
-    m: mrs.MRS, representative_priority: Callable = None
+    m: mrs.MRS, representative_priority: Optional[Callable] = None
 ) -> dmrs.DMRS:
     """
     Create a DMRS by converting from MRS *m*.
@@ -123,11 +123,13 @@ def _mrs_to_links(
     # links from arguments
     for src, roleargs in m.arguments().items():
         start = id_to_nid[src]
+        src_ep = cast(mrs.EP, m[src])
         for role, tgt in roleargs:
             # non-scopal arguments
             if tgt in iv_to_nid:
+                tgt_ep = cast(mrs.EP, m[tgt])
                 end = iv_to_nid[tgt]
-                if m[src].label == m[tgt].label:
+                if src_ep.label == tgt_ep.label:
                     post = dmrs.EQ_POST
                 else:
                     post = dmrs.NEQ_POST

--- a/delphin/eds/_eds.py
+++ b/delphin/eds/_eds.py
@@ -3,7 +3,7 @@
 Elementary Dependency Structures (EDS).
 """
 
-from typing import Iterable
+from typing import Iterable, Optional
 
 from delphin.lnk import Lnk
 from delphin.sembase import Predication, SemanticStructure
@@ -50,11 +50,11 @@ class Node(Predication):
     def __init__(self,
                  id: int,
                  predicate: str,
-                 type: str = None,
-                 edges: dict = None,
-                 properties: dict = None,
-                 carg: str = None,
-                 lnk: Lnk = None,
+                 type: Optional[str] = None,
+                 edges: Optional[dict] = None,
+                 properties: Optional[dict] = None,
+                 carg: Optional[str] = None,
+                 lnk: Optional[Lnk] = None,
                  surface=None,
                  base=None):
 
@@ -98,9 +98,9 @@ class EDS(SemanticStructure):
     __slots__ = ()
 
     def __init__(self,
-                 top: str = None,
-                 nodes: Iterable[Node] = None,
-                 lnk: Lnk = None,
+                 top: Optional[str] = None,
+                 nodes: Optional[Iterable[Node]] = None,
+                 lnk: Optional[Lnk] = None,
                  surface=None,
                  identifier=None):
         if nodes is None:

--- a/delphin/itsdb.py
+++ b/delphin/itsdb.py
@@ -85,7 +85,7 @@ class FieldMapper:
         affected_tables: list of tables that are affected by the
             processing
     """
-    def __init__(self, source: tsdb.Database = None):
+    def __init__(self, source: Optional[tsdb.Database] = None):
         # the parse keys exclude some that are handled specially
         self._parse_keys = '''
             ninputs ntokens readings first total tcpu tgc treal words
@@ -318,7 +318,7 @@ class Row(tsdb.Record):
     def __init__(self,
                  fields: tsdb.Fields,
                  data: Sequence[tsdb.Value],
-                 field_index: tsdb.FieldIndex = None):
+                 field_index: Optional[tsdb.FieldIndex] = None):
         if len(data) != len(fields):
             raise ITSDBError(
                 'number of columns ({}) != number of fields ({})'
@@ -640,7 +640,8 @@ class Table(tsdb.Relation):
 
     def _enum_rows(self,
                    fh: IO[str],
-                   _slice: slice = None) -> Iterator[Tuple[int, Row]]:
+                   _slice: Optional[slice] = None
+                   ) -> Iterator[Tuple[int, Row]]:
         """Enumerate on-disk and in-memory rows."""
         if _slice is None:
             _slice = slice(None)
@@ -690,8 +691,8 @@ class TestSuite(tsdb.Database):
     """
 
     def __init__(self,
-                 path: util.PathLike = None,
-                 schema: tsdb.SchemaLike = None,
+                 path: Optional[util.PathLike] = None,
+                 schema: Optional[tsdb.SchemaLike] = None,
                  encoding: str = 'utf-8') -> None:
         # Virtual test suites use a temporary directory
         if path is None:
@@ -733,7 +734,7 @@ class TestSuite(tsdb.Database):
 
     def select_from(self,
                     name: str,
-                    columns: Iterable[str] = None,
+                    columns: Optional[Iterable[str]] = None,
                     cast: bool = True):
         """
         Select fields given by *names* from each row in table *name*.
@@ -801,7 +802,8 @@ class TestSuite(tsdb.Database):
 
     def processed_items(
             self,
-            fieldmapper: FieldMapper = None) -> Iterator[interface.Response]:
+            fieldmapper: Optional[FieldMapper] = None
+    ) -> Iterator[interface.Response]:
         """
         Iterate over the data as :class:`Response` objects.
         """
@@ -812,12 +814,12 @@ class TestSuite(tsdb.Database):
     def process(
             self,
             cpu: interface.Processor,
-            selector: Tuple[str, str] = None,
-            source: tsdb.Database = None,
-            fieldmapper: FieldMapper = None,
+            selector: Optional[Tuple[str, str]] = None,
+            source: Optional[tsdb.Database] = None,
+            fieldmapper: Optional[FieldMapper] = None,
             gzip: bool = False,
             buffer_size: int = 1000,
-            callback: Callable[[interface.Response], Any] = None,
+            callback: Optional[Callable[[interface.Response], Any]] = None,
     ) -> None:
         """
         Process each item in a [incr tsdb()] test suite.

--- a/delphin/lnk.py
+++ b/delphin/lnk.py
@@ -3,6 +3,8 @@
 Surface alignment for semantic entities.
 """
 
+from typing import Optional, Tuple, Union, Iterable, overload
+
 from delphin.exceptions import PyDelphinException
 # Default modules need to import the PyDelphin version
 from delphin.__about__ import __version__  # noqa: F401
@@ -54,6 +56,9 @@ class Lnk:
 
     __slots__ = ('type', 'data')
 
+    type: int
+    data: Union[int, Tuple[int, ...]]
+
     # These types determine how a lnk on an EP or MRS are to be
     # interpreted, and thus determine the data type/structure of the
     # lnk data.
@@ -62,6 +67,20 @@ class Lnk:
     CHARTSPAN = 2  # Chart vertex span: a pair of indices
     TOKENS = 3  # Token numbers: a list of indices
     EDGE = 4  # An edge identifier: a number
+
+    @overload
+    def __init__(self, arg: None, data: None = None):
+        ...
+
+    @overload
+    def __init__(self, arg: str, data: None = None):
+        ...
+
+    @overload
+    def __init__(self,
+                 arg: int,
+                 data: Union[None, int, Tuple[int, ...]] = None):
+        ...
 
     def __init__(self, arg, data=None):
         if not arg:
@@ -97,7 +116,7 @@ class Lnk:
         return cls(None)
 
     @classmethod
-    def charspan(cls, start, end):
+    def charspan(cls, start: Union[str, int], end: Union[str, int]):
         """
         Create a Lnk object for a character span.
 
@@ -108,7 +127,7 @@ class Lnk:
         return cls(Lnk.CHARSPAN, (int(start), int(end)))
 
     @classmethod
-    def chartspan(cls, start, end):
+    def chartspan(cls, start: Union[str, int], end: Union[str, int]):
         """
         Create a Lnk object for a chart span.
 
@@ -119,7 +138,7 @@ class Lnk:
         return cls(Lnk.CHARTSPAN, (int(start), int(end)))
 
     @classmethod
-    def tokens(cls, tokens):
+    def tokens(cls, tokens: Iterable[Union[str, int]]):
         """
         Create a Lnk object for a token range.
 
@@ -129,7 +148,7 @@ class Lnk:
         return cls(Lnk.TOKENS, tuple(map(int, tokens)))
 
     @classmethod
-    def edge(cls, edge):
+    def edge(cls, edge: Union[str, int]):
         """
         Create a Lnk object for an edge (used internally in generation).
 
@@ -171,14 +190,16 @@ class LnkMixin:
 
     __slots__ = ('lnk', 'surface')
 
-    def __init__(self, lnk=None, surface=None):
+    def __init__(self,
+                 lnk: Optional[Lnk] = None,
+                 surface: Optional[str] = None):
         if lnk is None:
             lnk = Lnk.default()
         self.lnk = lnk
         self.surface = surface
 
     @property
-    def cfrom(self):
+    def cfrom(self) -> int:
         """
         The initial character position in the surface string.
 
@@ -187,13 +208,13 @@ class LnkMixin:
         cfrom = -1
         try:
             if self.lnk.type == Lnk.CHARSPAN:
-                cfrom = self.lnk.data[0]
+                cfrom = self.lnk.data[0]  # type: ignore
         except AttributeError:
             pass  # use default cfrom of -1
         return cfrom
 
     @property
-    def cto(self):
+    def cto(self) -> int:
         """
         The final character position in the surface string.
 
@@ -202,7 +223,7 @@ class LnkMixin:
         cto = -1
         try:
             if self.lnk.type == Lnk.CHARSPAN:
-                cto = self.lnk.data[1]
+                cto = self.lnk.data[1]  # type: ignore
         except AttributeError:
             pass  # use default cto of -1
         return cto

--- a/delphin/mrs/_mrs.py
+++ b/delphin/mrs/_mrs.py
@@ -1,5 +1,5 @@
 
-from typing import Optional, Iterable, Mapping
+from typing import Optional, Iterable, Mapping, Dict
 
 from delphin.lnk import Lnk
 from delphin import variable
@@ -52,8 +52,8 @@ class EP(sembase.Predication):
     def __init__(self,
                  predicate: str,
                  label: str,
-                 args: dict = None,
-                 lnk: Lnk = None,
+                 args: Optional[Dict[str, str]] = None,
+                 lnk: Optional[Lnk] = None,
                  surface=None,
                  base=None):
         self.id: str  # further constrain for EPs
@@ -63,6 +63,7 @@ class EP(sembase.Predication):
         # EPs formally do not have identifiers but they are very useful
         # note that the ARG0 may be unspecified, so use a default
         iv = args.get(INTRINSIC_ROLE, '_0')
+        type: Optional[str]
         type, vid = variable.split(iv)
         if type == '_':
             type = None
@@ -222,13 +223,13 @@ class MRS(scope.ScopingSemanticStructure):
     __slots__ = ('hcons', 'icons', 'variables')
 
     def __init__(self,
-                 top: str = None,
-                 index: str = None,
-                 rels: Iterable[EP] = None,
-                 hcons: Iterable[HCons] = None,
-                 icons: Iterable[ICons] = None,
-                 variables: Mapping[str, Mapping[str, str]] = None,
-                 lnk: Lnk = None,
+                 top: Optional[str] = None,
+                 index: Optional[str] = None,
+                 rels: Optional[Iterable[EP]] = None,
+                 hcons: Optional[Iterable[HCons]] = None,
+                 icons: Optional[Iterable[ICons]] = None,
+                 variables: Optional[Mapping[str, Mapping[str, str]]] = None,
+                 lnk: Optional[Lnk] = None,
                  surface=None,
                  identifier=None):
 

--- a/delphin/mrs/_operations.py
+++ b/delphin/mrs/_operations.py
@@ -3,7 +3,7 @@
 Operations on MRS structures
 """
 
-from typing import Iterable, Dict, Set, Optional
+from typing import Iterable, Dict, Set, cast
 
 from delphin import variable
 from delphin import predicate
@@ -118,8 +118,9 @@ def plausibly_scopes(m: mrs.MRS) -> bool:
         return False
     seen = set([m.top])
     for id, roleargs in m.arguments(types='h').items():
+        ep = cast(mrs.EP, m[id])
         for _, handle in roleargs:
-            if handle == m[id].label:
+            if handle == ep.label:
                 return False
             elif handle in hcmap:
                 if handle in seen:
@@ -168,8 +169,8 @@ def is_isomorphic(m1: mrs.MRS,
     return set(iso) == set(g1)
 
 
-def _make_mrs_isograph(x, properties):
-    g: Dict[Identifier, Dict[Optional[Identifier], str]] = {}
+def _make_mrs_isograph(x: mrs.MRS, properties: bool) -> util._IsoGraph:
+    g: util._IsoGraph = {}
     g.update((v, {}) for v in x.variables)
     g.update((ep.id, {}) for ep in x.rels)
 

--- a/delphin/predicate.py
+++ b/delphin/predicate.py
@@ -3,6 +3,7 @@
 Semantic predicates.
 """
 
+from typing import Tuple, Optional
 import re
 
 from delphin.exceptions import PyDelphinException
@@ -40,7 +41,7 @@ _robust_predicate_re = re.compile(
     flags=re.IGNORECASE)
 
 
-def _strip_predicate(s):
+def _strip_predicate(s: str) -> str:
     """Remove quotes and _rel suffix from predicate *s*"""
     if s.startswith('"') and s.endswith('"'):
         s = s[1:-1]
@@ -51,7 +52,7 @@ def _strip_predicate(s):
     return s
 
 
-def split(s):
+def split(s: str) -> Tuple[str, Optional[str], Optional[str]]:
     """
     Split predicate string *s* and return the lemma, pos, and sense.
 
@@ -78,7 +79,7 @@ def split(s):
     return (match.group('lemma'), match.group('pos'), match.group('sense'))
 
 
-def create(lemma, pos, sense=None):
+def create(lemma: str, pos: str, sense: Optional[str] = None) -> str:
     """
     Create a surface predicate string from its *lemma*, *pos*, and *sense*.
 
@@ -105,7 +106,7 @@ def create(lemma, pos, sense=None):
     return '_' + '_'.join(parts)
 
 
-def normalize(s):
+def normalize(s: str) -> str:
     """
     Normalize the predicate string *s* to a conventional form.
 
@@ -123,7 +124,7 @@ def normalize(s):
     return _s
 
 
-def is_valid(s):
+def is_valid(s: str) -> bool:
     """
     Return `True` if *s* is a valid predicate string.
 
@@ -141,7 +142,7 @@ def is_valid(s):
     return _strict_predicate_re.match(_s) is not None
 
 
-def is_surface(s):
+def is_surface(s: str) -> bool:
     """
     Return `True` if *s* is a valid surface predicate string.
 
@@ -160,7 +161,7 @@ def is_surface(s):
     return m is not None and m.lastindex == 1
 
 
-def is_abstract(s):
+def is_abstract(s: str) -> bool:
     """
     Return `True` if *s* is a valid abstract predicate string.
 

--- a/delphin/repp.py
+++ b/delphin/repp.py
@@ -247,7 +247,9 @@ class _REPPMask(_REPPOperation):
 
 class _REPPGroup(_REPPOperation):
     def __init__(
-        self, operations: List[_REPPOperation] = None, name: str = None
+        self,
+        operations: Optional[List[_REPPOperation]] = None,
+        name: Optional[str] = None
     ):
         if operations is None:
             operations = []
@@ -336,10 +338,10 @@ class REPP(_REPPGroup):
 
     def __init__(
         self,
-        operations: List[_REPPOperation] = None,
-        name: str = None,
-        modules: Dict[str, 'REPP'] = None,
-        active: Iterable[str] = None
+        operations: Optional[List[_REPPOperation]] = None,
+        name: Optional[str] = None,
+        modules: Optional[Dict[str, 'REPP']] = None,
+        active: Optional[Iterable[str]] = None
     ):
         super().__init__(operations=operations, name=name)
         self.info: Optional[str] = None
@@ -495,7 +497,11 @@ class REPP(_REPPGroup):
         else:
             logger.debug('>%s (inactive)', self.name)
 
-    def apply(self, s: str, active: Iterable[str] = None) -> REPPResult:
+    def apply(
+        self,
+        s: str,
+        active: Optional[Iterable[str]] = None
+    ) -> REPPResult:
         """
         Apply the REPP's rewrite rules to the input string *s*.
 
@@ -513,7 +519,10 @@ class REPP(_REPPGroup):
         return result
 
     def trace(
-        self, s: str, active: Iterable[str] = None, verbose: bool = False
+        self,
+        s: str,
+        active: Optional[Iterable[str]] = None,
+        verbose: bool = False
     ) -> _Trace:
         """
         Rewrite string *s* like `apply()`, but yield each rewrite step.
@@ -554,7 +563,10 @@ class REPP(_REPPGroup):
         yield REPPResult(s, startmap, endmap)
 
     def tokenize(
-        self, s: str, pattern: str = None, active: Iterable[str] = None
+        self,
+        s: str,
+        pattern: Optional[str] = None,
+        active: Optional[Iterable[str]] = None
     ) -> YYTokenLattice:
         """
         Rewrite and tokenize the input string *s*.

--- a/delphin/scope.py
+++ b/delphin/scope.py
@@ -128,7 +128,7 @@ def conjoin(scopes: ScopeMap, leqs: ScopeEqualities) -> ScopeMap:
 
 
 def descendants(x: ScopingSemanticStructure,
-                scopes: ScopeMap = None) -> DescendantMap:
+                scopes: Optional[ScopeMap] = None) -> DescendantMap:
     """
     Return a mapping of predication ids to their scopal descendants.
 

--- a/delphin/sembase.py
+++ b/delphin/sembase.py
@@ -169,10 +169,12 @@ class SemanticStructure(LnkMixin):
         return (self.top == other.top
                 and self.predications == other.predications)
 
-    def __contains__(self, id: Identifier):
+    def __contains__(self, id: Optional[Identifier]):
         return id in self._pidx
 
-    def __getitem__(self, id: Identifier) -> Predication:
+    def __getitem__(self, id: Optional[Identifier]) -> Predication:
+        if id is None:
+            raise KeyError(id)
         return self._pidx[id]
 
     def arguments(self,
@@ -193,11 +195,11 @@ class SemanticStructure(LnkMixin):
         """
         raise NotImplementedError()
 
-    def properties(self, id: Identifier) -> PropertyMap:
+    def properties(self, id: Optional[Identifier]) -> PropertyMap:
         """Return the morphosemantic properties for *id*."""
         raise NotImplementedError()
 
-    def is_quantifier(self, id: Identifier) -> bool:
+    def is_quantifier(self, id: Optional[Identifier]) -> bool:
         """Return `True` if *id* represents a quantifier."""
         raise NotImplementedError()
 

--- a/delphin/sembase.py
+++ b/delphin/sembase.py
@@ -3,7 +3,17 @@
 Basic classes and functions for semantic representations.
 """
 
-from typing import (Optional, Mapping, Tuple, List, Union, Sequence)
+from typing import (
+    Any,
+    Optional,
+    Iterable,
+    Mapping,
+    Tuple,
+    List,
+    Dict,
+    Union,
+    Sequence,
+)
 
 from delphin.lnk import Lnk, LnkMixin
 # Default modules need to import the PyDelphin version
@@ -142,7 +152,9 @@ class SemanticStructure(LnkMixin):
         super().__init__(lnk, surface)
         self.top = top
         self.predications = predications
-        self._pidx = {p.id: p for p in predications}
+        self._pidx: Dict[Identifier, Predication] = {
+            p.id: p for p in predications
+        }
         self.identifier = identifier
 
     def __repr__(self):
@@ -151,19 +163,22 @@ class SemanticStructure(LnkMixin):
             ' '.join(p.predicate for p in self.predications),
             id(self))
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any):
         if not isinstance(other, self.__class__):
             return NotImplemented
         return (self.top == other.top
                 and self.predications == other.predications)
 
-    def __contains__(self, id):
+    def __contains__(self, id: Identifier):
         return id in self._pidx
 
-    def __getitem__(self, id):
+    def __getitem__(self, id: Identifier) -> Predication:
         return self._pidx[id]
 
-    def arguments(self, types=None, expressed=None) -> ArgumentStructure:
+    def arguments(self,
+                  types: Optional[Iterable[str]] = None,
+                  expressed: Optional[bool] = None
+                  ) -> ArgumentStructure:
         """
         Return a mapping of the argument structure.
 

--- a/delphin/tsdb.py
+++ b/delphin/tsdb.py
@@ -109,8 +109,8 @@ class Field:
     def __init__(self,
                  name: str,
                  datatype: str,
-                 flags: Iterable[str] = None,
-                 comment: str = None) -> None:
+                 flags: Optional[Iterable[str]] = None,
+                 comment: Optional[str] = None) -> None:
         self.name = name
         self.datatype = datatype
         self.flags = tuple(flags or [])
@@ -335,7 +335,7 @@ class Database:
         return len(self.schema)
 
     def select_from(self, name: str,
-                    columns: Iterable[str] = None,
+                    columns: Optional[Iterable[str]] = None,
                     cast: bool = False) -> Generator[Record, None, None]:
         """
         Yield values for *columns* from relation *name*.
@@ -360,7 +360,8 @@ class Database:
     def _select_raw(
             self,
             name: str,
-            columns: Iterable[str] = None) -> Generator[RawRecord, None, None]:
+            columns: Optional[Iterable[str]] = None
+    ) -> Generator[RawRecord, None, None]:
         if name not in self.schema:
             raise TSDBError(f'relation not defined in schema: {name}')
         fields = self.schema[name]
@@ -438,7 +439,7 @@ def unescape(string: str) -> str:
 
 
 def split(line: str,
-          fields: Fields = None) -> Record:
+          fields: Optional[Fields] = None) -> Record:
     """
     Split a raw line from a relation into a list of column values.
 
@@ -468,7 +469,7 @@ def split(line: str,
 
 
 def join(values: Record,
-         fields: Fields = None) -> str:
+         fields: Optional[Fields] = None) -> str:
     """
     Join a list of column values into a string for a relation file.
 
@@ -770,7 +771,7 @@ def open(dir: util.PathLike,
 def write(dir: util.PathLike,
           name: str,
           records: Iterable[Record],
-          fields: Fields = None,
+          fields: Optional[Fields] = None,
           append: bool = False,
           gzip: bool = False,
           encoding: str = 'utf-8') -> None:
@@ -906,8 +907,8 @@ def initialize_database(path: util.PathLike,
 
 def write_database(db: Database,
                    path: util.PathLike,
-                   names: Iterable[str] = None,
-                   schema: SchemaLike = None,
+                   names: Optional[Iterable[str]] = None,
+                   schema: Optional[SchemaLike] = None,
                    gzip: bool = False,
                    encoding: str = 'utf-8') -> None:
     """

--- a/delphin/tsql.py
+++ b/delphin/tsql.py
@@ -48,7 +48,7 @@ class _Record(tsdb.Record):
     def __new__(cls,
                 fields: tsdb.Fields,
                 data: tsdb.Record,
-                field_index: tsdb.FieldIndex = None):
+                field_index: Optional[tsdb.FieldIndex] = None):
         return tuple(data)
 
 

--- a/delphin/variable.py
+++ b/delphin/variable.py
@@ -2,6 +2,7 @@
 Functions for working with MRS variables.
 """
 
+from typing import Tuple, Dict, List, Optional
 import re
 
 # Default modules need to import the PyDelphin version
@@ -21,9 +22,11 @@ HANDLE             = 'h'
 _variable_re = re.compile(r'^([-\w]*[^\s\d])(\d+)$')
 
 
-def split(var):
+def split(var: str) -> Tuple[str, str]:
     """
     Split a valid variable string into its variable type and id.
+
+    Note that, unlike :func:`id`, the id is returned as a string.
 
     Examples:
         >>> variable.split('h3')
@@ -35,10 +38,10 @@ def split(var):
     if match is None:
         raise ValueError(f'Invalid variable string: {var!s}')
     else:
-        return match.groups()
+        return match.group(1), match.group(2)
 
 
-def type(var):
+def type(var: str) -> str:
     """
     Return the type (i.e., sort) of a valid variable string.
 
@@ -56,7 +59,7 @@ def type(var):
 sort = type  #: :func:`sort` is an alias for :func:`type`.
 
 
-def id(var):
+def id(var: str) -> int:
     """
     Return the integer id of a valid variable string.
 
@@ -69,7 +72,7 @@ def id(var):
     return int(split(var)[1])
 
 
-def is_valid(var):
+def is_valid(var: str) -> bool:
     """
     Return `True` if *var* is a valid variable string.
 
@@ -100,12 +103,12 @@ class VariableFactory:
         store (dict): a mapping of variables to associated properties
     """
 
-    def __init__(self, starting_vid=1):
+    def __init__(self, starting_vid: int = 1):
         self.vid = starting_vid
-        self.index = {}  # to map vid to created variable
-        self.store = {}  # to recall properties from varstrings
+        self.index: Dict[int, str] = {}  # to map vid to created variable
+        self.store: Dict[str, List[str]] = {}  # variable to prop list
 
-    def new(self, type, properties=None):
+    def new(self, type: str, properties: Optional[List[str]] = None) -> str:
         """
         Create a new variable for the given *type*.
 


### PR DESCRIPTION
Fixing this in PyDelphin touched a lot of files but most changes were trivial. Along the way there were some typing gaps discovered and further work will be needed to fix some of these (e.g., the subclassing of MRS, EDS, and DMRS from the SemanticStructure violates the Liskov Substitution Principle on some methods).

This PR also restores the more strict Mypy checks in CI.